### PR TITLE
xp-dvb-modules-xp1000: Declare COMPATIBLE_MACHINE

### DIFF
--- a/recipes-bsp/drivers/xp-dvb-modules-xp1000.bb
+++ b/recipes-bsp/drivers/xp-dvb-modules-xp1000.bb
@@ -1,6 +1,8 @@
 KV = "4.0.1"
 SRCDATE = "20150618"
 
+COMPATIBLE_MACHINE = "xp1000"
+
 require xp-dvb-modules.inc
 SRC_URI[md5sum] = "b5cb4b5c5a6beb10e5af82a46636f478"
 SRC_URI[sha256sum] = "d1561886d71ebfadb8e709724f9e319e4ae87cced1c4fd73923430307c0a4617"


### PR DESCRIPTION
Prevent SRC_URI fetch warnings when building other boxes.
