### PR TITLE
Set KERNEL_OUTPUT_DIR variable and add GCC6 support

### DIFF
--- a/recipes-bsp/linux/linux-xp/kernel-gcc6.patch
+++ b/recipes-bsp/linux/linux-xp/kernel-gcc6.patch
@@ -1,0 +1,69 @@
+diff --git a/include/linux/compiler-gcc6.h b/include/linux/compiler-gcc6.h
+new file mode 100644
+index 0000000..ba064fa
+--- /dev/null
++++ b/include/linux/compiler-gcc6.h
+@@ -0,0 +1,59 @@
++#ifndef __LINUX_COMPILER_H
++#error "Please don't include <linux/compiler-gcc6.h> directly, include <linux/compiler.h> instead."
++#endif
++
++#define __used				__attribute__((__used__))
++#define __must_check			__attribute__((warn_unused_result))
++#define __compiler_offsetof(a, b)	__builtin_offsetof(a, b)
++
++/* Mark functions as cold. gcc will assume any path leading to a call
++   to them will be unlikely.  This means a lot of manual unlikely()s
++   are unnecessary now for any paths leading to the usual suspects
++   like BUG(), printk(), panic() etc. [but let's keep them for now for
++   older compilers]
++
++   gcc also has a __attribute__((__hot__)) to move hot functions into
++   a special section, but I don't see any sense in this right now in
++   the kernel context */
++#define __cold			__attribute__((__cold__))
++
++#define __UNIQUE_ID(prefix) __PASTE(__PASTE(__UNIQUE_ID_, prefix), __COUNTER__)
++
++#ifndef __CHECKER__
++# define __compiletime_warning(message) __attribute__((warning(message)))
++# define __compiletime_error(message) __attribute__((error(message)))
++#endif /* __CHECKER__ */
++
++/*
++ * Mark a position in code as unreachable.  This can be used to
++ * suppress control flow warnings after asm blocks that transfer
++ * control elsewhere.
++ */
++#define unreachable() __builtin_unreachable()
++
++/* Mark a function definition as prohibited from being cloned. */
++#define __noclone	__attribute__((__noclone__))
++
++/*
++ * Tell the optimizer that something else uses this function or variable.
++ */
++#define __visible __attribute__((externally_visible))
++
++/*
++ * GCC 'asm goto' miscompiles certain code sequences:
++ *
++ *   http://gcc.gnu.org/bugzilla/show_bug.cgi?id=58670
++ *
++ * Work it around via a compiler barrier quirk suggested by Jakub Jelinek.
++ *
++ * (asm goto is automatically volatile - the naming reflects this.)
++ */
++#define asm_volatile_goto(x...)	do { asm goto(x); asm (""); } while (0)
++
++#ifdef CONFIG_ARCH_USE_BUILTIN_BSWAP
++#define __HAVE_BUILTIN_BSWAP32__
++#define __HAVE_BUILTIN_BSWAP64__
++#define __HAVE_BUILTIN_BSWAP16__
++#endif /* CONFIG_ARCH_USE_BUILTIN_BSWAP */
++
++#define KASAN_ABI_VERSION 4
+-- 
+2.1.0
+
+  

--- a/recipes-bsp/linux/linux-xp_4.0.1.bb
+++ b/recipes-bsp/linux/linux-xp_4.0.1.bb
@@ -24,6 +24,7 @@ SRC_URI += "http://downloads.mutant-digital.net/linux-${PV}.tar.gz \
 	file://0001-bcmgenet.patch \
 	file://add-dmx-source-timecode.patch \
 	file://iosched-slice_idle-1.patch \
+	file://kernel-gcc6.patch \
 	"
 
 inherit kernel machine_kernel_pr
@@ -33,6 +34,7 @@ S = "${WORKDIR}/linux-${PV}"
 export OS = "Linux"
 KERNEL_OBJECT_SUFFIX = "ko"
 KERNEL_OUTPUT = "vmlinux"
+KERNEL_OUTPUT_DIR = "."
 KERNEL_IMAGETYPE = "vmlinux"
 KERNEL_IMAGEDEST = "/tmp"
 


### PR DESCRIPTION
KERNEL_OUTPUT_DIR defaults to arch/${ARCH}/boot, which isn't where
these kernels end up. Previously this was done with KERNEL_OUTPUT,
but now that the kernel class supports multiple recipes, setting
KERNEL_OUTPUT_DIR to "." fixes the kernel recipes no longer
building.

Workaround for missing gcc6 header in kernel.
