### PR TITLE
Set O32 default FPU flags 

### DIFF
--- a/recipes-bsp/linux/linux-xp/set_o32_default_fpu_flags.patch
+++ b/recipes-bsp/linux/linux-xp/set_o32_default_fpu_flags.patch
@@ -1,0 +1,53 @@
+From 48f8eaee3f59848809644507fc47363b37e54450 Mon Sep 17 00:00:00 2001
+From: Markos Chandras <markos.chandras@imgtec.com>
+Date: Thu, 26 Feb 2015 11:11:30 +0000
+Subject: MIPS: asm: elf: Set O32 default FPU flags
+
+Set good default FPU flags (FR0) for O32 binaries similar to what the
+kernel does for the N64/N32 ones. This also fixes a regression
+introduced in commit 46490b572544 ("MIPS: kernel: elf: Improve the
+overall ABI and FPU mode checks") when MIPS_O32_FP64_SUPPORT is
+disabled. In that case, the mips_set_personality_fp() did not set the
+FPU mode at all because it assumed that the FPU mode was already set
+properly. That led to O32 userland problems.
+
+Signed-off-by: Markos Chandras <markos.chandras@imgtec.com>
+Reported-by: Mans Rullgard <mans@mansr.com>
+Fixes: 46490b572544 ("MIPS: kernel: elf: Improve the overall ABI and FPU mode checks")
+Tested-by: Mans Rullgard <mans@mansr.com>
+Tested-by: Aaro Koskinen <aaro.koskinen@iki.fi>
+Cc: Matthew Fortune <Matthew.Fortune@imgtec.com>
+Cc: Paul Burton <paul.burton@imgtec.com>
+Cc: linux-mips@linux-mips.org
+Patchwork: http://patchwork.linux-mips.org/patch/9344/
+Signed-off-by: Ralf Baechle <ralf@linux-mips.org>
+---
+ arch/mips/include/asm/elf.h | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/arch/mips/include/asm/elf.h b/arch/mips/include/asm/elf.h
+index 535f196..694925a 100644
+--- a/arch/mips/include/asm/elf.h
++++ b/arch/mips/include/asm/elf.h
+@@ -294,6 +294,9 @@ do {									\
+ 	if (personality(current->personality) != PER_LINUX)		\
+ 		set_personality(PER_LINUX);				\
+ 									\
++	clear_thread_flag(TIF_HYBRID_FPREGS);				\
++	set_thread_flag(TIF_32BIT_FPREGS);				\
++									\
+ 	mips_set_personality_fp(state);					\
+ 									\
+ 	current->thread.abi = &mips_abi;				\
+@@ -319,6 +322,8 @@ do {									\
+ 	do {								\
+ 		set_thread_flag(TIF_32BIT_REGS);			\
+ 		set_thread_flag(TIF_32BIT_ADDR);			\
++		clear_thread_flag(TIF_HYBRID_FPREGS);			\
++		set_thread_flag(TIF_32BIT_FPREGS);			\
+ 									\
+ 		mips_set_personality_fp(state);				\
+ 									\
+-- 
+cgit v1.1
+

--- a/recipes-bsp/linux/linux-xp_4.0.1.bb
+++ b/recipes-bsp/linux/linux-xp_4.0.1.bb
@@ -4,7 +4,7 @@ LICENSE = "GPLv2"
 
 KERNEL_RELEASE = "4.0.1"
 COMPATIBLE_MACHINE = "xp1000"
-MACHINE_KERNEL_PR_append = ".3"
+MACHINE_KERNEL_PR_append = ".4"
 
 SRC_URI[md5sum] = "c274792d088cd7bbfe7fe5a76bd798d8"
 SRC_URI[sha256sum] = "6fd63aedd69b3b3b28554cabf71a9efcf05f10758db3d5b99cfb0580e3cde24c"
@@ -24,6 +24,7 @@ SRC_URI += "http://downloads.mutant-digital.net/linux-${PV}.tar.gz \
 	file://0001-bcmgenet.patch \
 	file://add-dmx-source-timecode.patch \
 	file://iosched-slice_idle-1.patch \
+	file://set_o32_default_fpu_flags.patch \
 	file://kernel-gcc6.patch \
 	"
 


### PR DESCRIPTION
This fixes a regression introduced in commit 46490b572544 ("MIPS: kernel: elf: Improve the overall ABI and FPU mode checks")
More info:
https://forums.openpli.org/topic/54431-openpli-6-the-soft-float-abiflags-no-abiflags-accessing-a-corrupted-shared-library/


